### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "metastore",
     "name_pretty": "Dataproc Metastore",
     "product_documentation": "https://cloud.google.com/dataproc-metastore/",
-    "client_documentation": "https://googleapis.dev/python/metastore/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/metastore/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ metastore and serves as a critical component towards enterprise data lakes.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-dataproc-metastore.svg
    :target: https://pypi.org/project/google-cloud-dataproc-metastore/
 .. _Dataproc Metastore: https://cloud.google.com/dataproc-metastore/docs
-.. _Client Library Documentation: https://googleapis.dev/python/metastore/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/metastore/latest
 .. _Product Documentation:  https://cloud.google.com/dataproc-metastore/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.